### PR TITLE
feat: add localization for products and taxons

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@spree/axios-fetcher": "^1.0.0",
-    "@spree/storefront-api-v2-sdk": "6.0.2",
+    "@spree/storefront-api-v2-sdk": "6.0.3",
     "@vue-storefront/core": "^2.5.0"
   },
   "files": [

--- a/packages/api-client/src/api/getCategory/index.ts
+++ b/packages/api-client/src/api/getCategory/index.ts
@@ -4,8 +4,13 @@ import { deserializeCategories } from '../serializers/category';
 
 const findCategory = (categories: Category[], slug: string) => categories.find(e => e.slug === slug);
 
-export default async function getCategory({ client }: ApiContext, { categorySlug }: GetCategoryParams): Promise<CategorySearchResult> {
-  const result = await client.taxons.list({ fields: { taxon: 'name,permalink,children,parent,is_root' }, per_page: 500 });
+export default async function getCategory({ client, config }: ApiContext, { categorySlug }: GetCategoryParams): Promise<CategorySearchResult> {
+  const locale = await config.internationalization.getLocale();
+  const result = await client.taxons.list({
+    fields: { taxon: 'name,permalink,children,parent,is_root' },
+    per_page: 500,
+    locale
+  });
 
   if (result.isSuccess()) {
     try {

--- a/packages/api-client/src/api/getProduct/index.ts
+++ b/packages/api-client/src/api/getProduct/index.ts
@@ -4,6 +4,7 @@ import { addHostToProductImages, deserializeSingleProductVariants } from '../ser
 
 export default async function getProduct({ client, config }: ApiContext, { slug }: GetProductParams): Promise<ProductVariant[]> {
   const currency = await config.internationalization.getCurrency();
+  const locale = await config.internationalization.getLocale();
 
   let include;
 
@@ -21,7 +22,8 @@ export default async function getProduct({ client, config }: ApiContext, { slug 
         variant: 'sku,price,display_price,in_stock,product,images,option_values,is_master'
       },
       include,
-      currency
+      currency,
+      locale
     }
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3133,10 +3133,10 @@
   resolved "https://registry.yarnpkg.com/@spree/axios-fetcher/-/axios-fetcher-1.0.0.tgz#d990ed38ee8bc33706f196a797f90117f8bd4d6d"
   integrity sha512-mflTBxdhiYAlVvHqZnzsDOs2w4e3CDIUTa4SvK6X9jZy7VhWhPocS9u8Zo8nsLm77kus2oeq3jcZljbEJEbEhw==
 
-"@spree/storefront-api-v2-sdk@6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@spree/storefront-api-v2-sdk/-/storefront-api-v2-sdk-6.0.2.tgz#67470a750a26f5c8cddf5b78be90d483aa06832f"
-  integrity sha512-zcMGuyyqaotGWE4ymkRNFrTddzSjbJ29yvTkeUxpunYFf1ZfwwxWJvGXC7TbdIwIBmIBGMdTxb/wWCh8qUmzRw==
+"@spree/storefront-api-v2-sdk@6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@spree/storefront-api-v2-sdk/-/storefront-api-v2-sdk-6.0.3.tgz#b04886216258fe6565ca0af3fb84b6e7818d6c44"
+  integrity sha512-C2aoaGzQqJRBFxipxecDOk3Sy6auzJsVsqVgJuUJyfkf6vtb78U3sqJPZ80S8XrlnCaw2M6an+Hm5uDW1byzqA==
 
 "@storefront-ui/shared@0.11.0":
   version "0.11.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds current locale to Spree api calls params for getting the products and taxons. The locale is being taken from the cookie set by i18n nuxt plugin.

Spree SDK PR: https://github.com/spree/spree-api-v2-js-sdk/pull/364

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
