### PR TITLE
fix: add menu prop checks in the menu components

### DIFF
--- a/packages/theme/components/HeaderNavigation/DesktopMenu.vue
+++ b/packages/theme/components/HeaderNavigation/DesktopMenu.vue
@@ -33,7 +33,7 @@ export default {
     }
   },
   setup(props) {
-    const isMenuAvailable = computed(() => !props.menu.isDisabled);
+    const isMenuAvailable = computed(() => props.menu && !props.menu.isDisabled);
 
     return {
       isMenuAvailable

--- a/packages/theme/components/HeaderNavigation/MobileMenu.vue
+++ b/packages/theme/components/HeaderNavigation/MobileMenu.vue
@@ -72,7 +72,7 @@ export default {
   },
   setup(props) {
     const { isMobileMenuOpen, toggleMobileMenu } = useUiState();
-    const isMenuAvailable = computed(() => !props.menu.isDisabled);
+    const isMenuAvailable = computed(() => props.menu && !props.menu.isDisabled);
 
     return {
       isMenuAvailable,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds additional checks for the menu prop which is falsy when the menu is not configured in Spree backend. With the checks in place, only a "please configure..." info will show up on the frontend.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
