### PR TITLE
fix: prepend hostname to image urls only when it's not preset

### DIFF
--- a/packages/api-client/src/api/serializers/product.ts
+++ b/packages/api-client/src/api/serializers/product.ts
@@ -234,11 +234,17 @@ const addHostToImage = (image, config: ApiConfig) => ({
   ...image,
   attributes: {
     ...image.attributes,
-    styles: image.attributes?.styles ? image.attributes.styles.map((style) => ({
-      width: style.width,
-      height: style.height,
-      url: `${style.url.includes('http') ? '' : (config.assetsUrl || config.backendUrl)}${style.url}`
-    })) : []
+    styles: image.attributes?.styles ? image.attributes.styles.map((style) => {
+      const host = style.url.startsWith('http://') || style.url.startsWith('https://')
+        ? ''
+        : (config.assetsUrl || config.backendUrl);
+
+      return {
+        width: style.width,
+        height: style.height,
+        url: `${host}${style.url}`
+      };
+    }) : []
   }
 });
 

--- a/packages/api-client/src/api/serializers/product.ts
+++ b/packages/api-client/src/api/serializers/product.ts
@@ -237,7 +237,7 @@ const addHostToImage = (image, config: ApiConfig) => ({
     styles: image.attributes?.styles ? image.attributes.styles.map((style) => ({
       width: style.width,
       height: style.height,
-      url: (config.assetsUrl || config.backendUrl) + style.url
+      url: `${style.url.includes('http') ? '' : (config.assetsUrl || config.backendUrl)}${style.url}`
     })) : []
   }
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR removes the addHostToImage function from the api serializers and all of the places it has been referenced.

## Description
<!--- Describe your changes in detail -->
Before a product image url coming from Spree didn't include the host. Right now it returns a full url so it's not needed to prefix the host.

Images weren't showing because the final url was invalid.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
