### PR TITLE
feat: add language switcher based on localized slugs coming from Spree

### DIFF
--- a/packages/api-client/src/api/getCategory/index.ts
+++ b/packages/api-client/src/api/getCategory/index.ts
@@ -7,7 +7,7 @@ const findCategory = (categories: Category[], slug: string) => categories.find(e
 export default async function getCategory({ client, config }: ApiContext, { categorySlug }: GetCategoryParams): Promise<CategorySearchResult> {
   const locale = await config.internationalization.getLocale();
   const result = await client.taxons.list({
-    fields: { taxon: 'name,permalink,children,parent,is_root' },
+    fields: { taxon: 'name,permalink,localized_slugs,children,parent,is_root' },
     per_page: 500,
     locale
   });

--- a/packages/api-client/src/api/getProduct/index.ts
+++ b/packages/api-client/src/api/getProduct/index.ts
@@ -18,7 +18,7 @@ export default async function getProduct({ client, config }: ApiContext, { slug 
     {
       id: slug,
       fields: {
-        product: 'name,slug,sku,description,primary_variant,default_variant,variants,option_types,product_properties,taxons',
+        product: 'name,slug,localized_slugs,sku,description,primary_variant,default_variant,variants,option_types,product_properties,taxons',
         variant: 'sku,price,display_price,in_stock,product,images,option_values,is_master'
       },
       include,

--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -6,6 +6,7 @@ import { deserializeSearchMetadata } from '../serializers/search';
 export default async function getProducts({ client, config }: ApiContext, params: GetProductsParams): Promise<ProductSearchResult> {
   try {
     const currency = await config.internationalization.getCurrency();
+    const locale = await config.internationalization.getLocale();
     const { categoryId, term, optionTypeFilters, productPropertyFilters, priceFilter, page, itemsPerPage, sort } = params;
     let include;
 
@@ -44,7 +45,8 @@ export default async function getProducts({ client, config }: ApiContext, params
         page,
         sort,
         per_page: itemsPerPage,
-        currency
+        currency,
+        locale
       }
     );
 

--- a/packages/api-client/src/api/serializers/category.ts
+++ b/packages/api-client/src/api/serializers/category.ts
@@ -1,3 +1,9 @@
+const serializeCategoryBase = (category) => ({
+  id: category.id,
+  name: category.attributes.name,
+  slug: category.attributes.permalink,
+  localizedSlugs: category.attributes.localized_slugs
+});
 
 const findParent = (taxon, apiTaxons) => {
   if (taxon.attributes.is_root) {
@@ -9,9 +15,7 @@ const findParent = (taxon, apiTaxons) => {
   const parent = apiTaxons.find(taxon => taxon.id === parentId);
 
   return {
-    id: parent.id,
-    name: parent.attributes.name,
-    slug: parent.attributes.permalink,
+    ...serializeCategoryBase(parent),
     parent: findParent(parent, apiTaxons)
   };
 };
@@ -23,9 +27,7 @@ const findItems = (taxon, apiTaxons) => {
   const items = apiTaxons.filter(taxon => taxonIds.includes(taxon.id));
 
   return items.map(item => ({
-    id: item.id,
-    name: item.attributes.name,
-    slug: item.attributes.permalink,
+    ...serializeCategoryBase(item),
     items: findItems(item, apiTaxons),
     parent: findParent(item, apiTaxons)
   }));
@@ -33,9 +35,7 @@ const findItems = (taxon, apiTaxons) => {
 
 export const deserializeCategories = (apiTaxons) =>
   apiTaxons.map(taxon => ({
-    id: taxon.id,
-    name: taxon.attributes.name,
-    slug: taxon.attributes.permalink,
+    ...serializeCategoryBase(taxon),
     items: findItems(taxon, apiTaxons),
     parent: findParent(taxon, apiTaxons)
   }));

--- a/packages/api-client/src/api/serializers/category.ts
+++ b/packages/api-client/src/api/serializers/category.ts
@@ -2,7 +2,7 @@ const serializeCategoryBase = (category) => ({
   id: category.id,
   name: category.attributes.name,
   slug: category.attributes.permalink,
-  localizedSlugs: category.attributes.localized_slugs
+  localizedSlugs: category.attributes.localized_slugs || {}
 });
 
 const findParent = (taxon, apiTaxons) => {

--- a/packages/api-client/src/api/serializers/product.ts
+++ b/packages/api-client/src/api/serializers/product.ts
@@ -142,6 +142,7 @@ const partialDeserializeProductVariant = (
   _categoriesRef: product.relationships.taxons.data.map((taxon) => taxon.id),
   name: product.attributes.name,
   slug: product.attributes.slug,
+  localizedSlugs: product.attributes.localized_slugs,
   sku: product.attributes.sku,
   optionTypes: deserializeOptionTypes(attachments, product),
   optionValues: deserializeOptionValues(attachments, variant),

--- a/packages/api-client/src/api/serializers/product.ts
+++ b/packages/api-client/src/api/serializers/product.ts
@@ -142,7 +142,7 @@ const partialDeserializeProductVariant = (
   _categoriesRef: product.relationships.taxons.data.map((taxon) => taxon.id),
   name: product.attributes.name,
   slug: product.attributes.slug,
-  localizedSlugs: product.attributes.localized_slugs,
+  localizedSlugs: product.attributes.localized_slugs || {},
   sku: product.attributes.sku,
   optionTypes: deserializeOptionTypes(attachments, product),
   optionValues: deserializeOptionValues(attachments, variant),

--- a/packages/api-client/src/types/category.ts
+++ b/packages/api-client/src/types/category.ts
@@ -2,6 +2,9 @@ export type Category = {
   id: number;
   name: string;
   slug: string;
+  localizedSlugs: {
+    [key: string]: string;
+  };
   items?: Category[];
   parent?: Category;
 };
@@ -14,3 +17,15 @@ export type CategorySearchResult = {
 export type GetCategoryParams = {
   categorySlug: string;
 };
+
+export interface AgnosticCategoryTree {
+  label: string;
+  slug?: string;
+  localizedSlugs: {
+    [key: string]: string;
+  };
+  items: AgnosticCategoryTree[];
+  isCurrent: boolean;
+  count?: number;
+  [x: string]: unknown;
+}

--- a/packages/api-client/src/types/product.ts
+++ b/packages/api-client/src/types/product.ts
@@ -41,6 +41,9 @@ export type ProductVariant = {
   _categoriesRef: string[];
   name: string;
   slug: string;
+  localizedSlugs: {
+    [key: string]: string;
+  };
   sku: string;
   images: Image[];
   properties: Property[];

--- a/packages/composables/src/getters/categoryGetters.ts
+++ b/packages/composables/src/getters/categoryGetters.ts
@@ -1,5 +1,5 @@
-import { CategoryGetters, AgnosticCategoryTree, AgnosticBreadcrumb } from '@vue-storefront/core';
-import { Category } from '@vue-storefront/spree-api/src/types';
+import { CategoryGetters, AgnosticBreadcrumb } from '@vue-storefront/core';
+import { Category, AgnosticCategoryTree } from './../../../api-client/src/types';
 
 export const getCategoryTree = (categories: any): AgnosticCategoryTree => {
   const { root, current } = categories;
@@ -7,6 +7,7 @@ export const getCategoryTree = (categories: any): AgnosticCategoryTree => {
   const itemToTree = (category: Category) => ({
     label: category.name,
     slug: category.slug,
+    localizedSlugs: category.localizedSlugs,
     items: category.items.map(itemToTree),
     isCurrent: category.id === current.id
   });

--- a/packages/theme/helpers/localizedSlugsToRouteParams.ts
+++ b/packages/theme/helpers/localizedSlugsToRouteParams.ts
@@ -1,0 +1,23 @@
+// parses { en: 'jacket', de: 'jacket-de' }
+// to { en: { slug: 'jacket' }, de: { slug: 'jacket-de' } }
+
+// parses { en: 'bestsellers/jacket', de: 'bestsellers-de/jacket-de' }
+// to { en: { slug_1: 'bestsellers', slug_2: 'jacket' }, de: { slug_1: 'bestsellers-de', slug_2: 'jacket-de' } }
+
+const localizedSlugsToRouteParams = (localizedSlugs) => {
+  return Object.keys(localizedSlugs)
+    .reduce((acc, locale) => {
+      const permalink = localizedSlugs[locale];
+      const slugs = permalink.split('/').filter(Boolean);
+
+      return {
+        ...acc,
+        [locale]:
+          slugs.length === 1
+            ? { slug: slugs[0] }
+            : slugs.reduce((slugAcc, slug, idx) => ({ ...slugAcc, [`slug_${idx + 1}`]: slug }), {})
+      };
+    }, {});
+};
+
+export default localizedSlugsToRouteParams;

--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -270,7 +270,7 @@ export default {
     };
 
     watch(result, (value) => {
-      if (value && value.data) {
+      if (value && value.data && Object.keys(value.data.categories.current.localizedSlugs).length) {
         const routeParams = localizedSlugsToRouteParams(value.data.categories.current.localizedSlugs);
         context.store.dispatch('i18n/setRouteParams', routeParams);
       }

--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -217,12 +217,13 @@ import {
   SfColor,
   SfProperty
 } from '@storefront-ui/vue';
-import { computed, useContext } from '@nuxtjs/composition-api';
+import { computed, useContext, watch } from '@nuxtjs/composition-api';
 import { useCart, useWishlist, productGetters, useFacet, facetGetters, useUser, wishlistGetters } from '@vue-storefront/spree';
 import { useUiHelpers, useUiState } from '~/composables';
 import { onSSR } from '@vue-storefront/core';
 import LazyHydrate from 'vue-lazy-hydration';
 import CategoryPageHeader from '~/components/CategoryPageHeader';
+import localizedSlugsToRouteParams from '~/helpers/localizedSlugsToRouteParams';
 
 // TODO(addToCart qty, horizontal): https://github.com/vuestorefront/storefront-ui/issues/1606
 export default {
@@ -267,6 +268,13 @@ export default {
         await removeItemFromWishlist({ product });
       }
     };
+
+    watch(result, (value) => {
+      if (value && value.data) {
+        const routeParams = localizedSlugsToRouteParams(value.data.categories.current.localizedSlugs);
+        context.store.dispatch('i18n/setRouteParams', routeParams);
+      }
+    }, { immediate: true, deep: true });
 
     onSSR(async () => {
       await search(th.getFacetsFromURL());

--- a/packages/theme/pages/Product.vue
+++ b/packages/theme/pages/Product.vue
@@ -134,10 +134,11 @@ import {
 
 import InstagramFeed from '~/components/InstagramFeed.vue';
 import RelatedProducts from '~/components/RelatedProducts.vue';
-import { ref, computed, useRoute, useRouter, useContext } from '@nuxtjs/composition-api';
+import { ref, computed, useRoute, useRouter, useContext, watch } from '@nuxtjs/composition-api';
 import { useProduct, useCart, productGetters } from '@vue-storefront/spree';
 import { onSSR } from '@vue-storefront/core';
 import LazyHydrate from 'vue-lazy-hydration';
+import localizedSlugsToRouteParams from '~/helpers/localizedSlugsToRouteParams';
 
 export default {
   name: 'Product',
@@ -166,6 +167,13 @@ export default {
       await search({ slug });
       await searchRelatedProducts({ categoryId: [categories.value[0]], limit: 8 });
     });
+
+    watch(product, (value) => {
+      if (value && value.localizedSlugs) {
+        const routeParams = localizedSlugsToRouteParams(product.value.localizedSlugs);
+        context.store.dispatch('i18n/setRouteParams', routeParams);
+      }
+    }, { immediate: true });
 
     const updateFilter = (filter) => {
       router.push({

--- a/packages/theme/pages/Product.vue
+++ b/packages/theme/pages/Product.vue
@@ -169,8 +169,8 @@ export default {
     });
 
     watch(product, (value) => {
-      if (value && value.localizedSlugs) {
-        const routeParams = localizedSlugsToRouteParams(product.value.localizedSlugs);
+      if (value && value.localizedSlugs && Object.keys(value.localizedSlugs).length) {
+        const routeParams = localizedSlugsToRouteParams(value.localizedSlugs);
         context.store.dispatch('i18n/setRouteParams', routeParams);
       }
     }, { immediate: true });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the `localized_slugs` property to product and taxon serializers making it accessible on the frontend. Then it is being parsed by the `localizedSlugsToRouteParams` function and passed to the `i18n/setRouteParams` dispatch to set the alternative routes ([docs](https://i18n-legacy.nuxtjs.org/lang-switcher#dynamic-route-parameters)).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When switching between languages on product and category page the user should be redirected to the translated url defined in Spree backend.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
visually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
