### PR TITLE
feat: base url subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ module.exports = {
 
 ```
 
+## Serving under a subpath
+
+You might want to serve your store under a subpath (for example: `https://example.com/shop/`). In order to do that, you just have to add a `BASE_URL` environment variable to the `.env.production` file containing a full url.
+
+Note that in development it will still be served on the root path (`http://localhost:3000` by default) unless you change the `.env.development` file too.
+
 ## Repository structure
 
 The monorepo contains three submodules:

--- a/packages/theme/nuxt.config.ts
+++ b/packages/theme/nuxt.config.ts
@@ -177,6 +177,7 @@ export default {
     ]
   },
   router: {
+    base: new URL(serverConfig.baseUrl).pathname,
     middleware: ['checkout'],
     scrollBehavior (_to, _from, savedPosition) {
       if (savedPosition) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This PR adds a `base` property to the router config based on the `BASE_URL` env variable making it easy to configure the store to be served under a subpath.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/vuestorefront-community/spree/issues/294

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
